### PR TITLE
Minor Fixes

### DIFF
--- a/src/ballyregan/core/logger.py
+++ b/src/ballyregan/core/logger.py
@@ -1,7 +1,7 @@
 import sys
 from loguru import logger
 
-from ballyregan.core.exceptions import InvalidDebugMode
+from ..core.exceptions import InvalidDebugMode
 
 
 def set_logger_level(log_level: str):

--- a/src/ballyregan/core/utils.py
+++ b/src/ballyregan/core/utils.py
@@ -1,7 +1,5 @@
 import asyncio
-
-from pythonping import ping
-
+import requests
 
 def has_internet_connection() -> bool:
     """Check wether or not the system is connected to a network
@@ -10,7 +8,7 @@ def has_internet_connection() -> bool:
         bool: Connected or not
     """
     try:
-        ping('google.com', verbose=False, timeout=2, count=2)
+        requests.get('https://www.google.com')
     except:
         return False
     else:

--- a/src/ballyregan/fetcher.py
+++ b/src/ballyregan/fetcher.py
@@ -7,14 +7,14 @@ from concurrent.futures import ThreadPoolExecutor
 
 from loguru import logger
 
-from ballyregan import Proxy
-from ballyregan.models import Protocols, Anonymities
-from ballyregan.core.exceptions import NoProxiesFound, NoInternetConnection
-from ballyregan.core.logger import init_logger
-from ballyregan.core.utils import has_internet_connection, get_event_loop
-from ballyregan.validator import ProxyValidator
-from ballyregan.filterer import ProxyFilterer
-from ballyregan.providers import IProxyProvider, FreeProxyListProvider, GeonodeProvider, SSLProxiesProvider, USProxyProvider, ProxyListDownloadProvider, SocksProxyProvider
+from . import Proxy
+from .models import Protocols, Anonymities
+from .core.exceptions import NoProxiesFound, NoInternetConnection
+from .core.logger import init_logger
+from .core.utils import has_internet_connection, get_event_loop
+from .validator import ProxyValidator
+from .filterer import ProxyFilterer
+from .providers import IProxyProvider, FreeProxyListProvider, GeonodeProvider, SSLProxiesProvider, USProxyProvider, ProxyListDownloadProvider, SocksProxyProvider
 
 
 @dataclass

--- a/src/ballyregan/filterer.py
+++ b/src/ballyregan/filterer.py
@@ -2,8 +2,8 @@ from typing import List
 
 from loguru import logger
 
-from ballyregan import Proxy
-from ballyregan.models import Protocols, Anonymities
+from . import Proxy
+from .models import Protocols, Anonymities
 
 
 class ProxyFilterer:

--- a/src/ballyregan/models/proxy.py
+++ b/src/ballyregan/models/proxy.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional, Union
 
-from ballyregan.models import HashableBaseModel
+from ..models import HashableBaseModel
 
 UNKNOWN = 'unknown'
 

--- a/src/ballyregan/providers/free_proxy_list.py
+++ b/src/ballyregan/providers/free_proxy_list.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 import pandas
 from requests.exceptions import ConnectionError
 
-from ballyregan import Proxy
-from ballyregan.models import Protocols
-from ballyregan.providers import IProxyProvider
-from ballyregan.core.exceptions import ProxyGatherException, ProxyParseException
+from .. import Proxy
+from ..models import Protocols
+from ..providers import IProxyProvider
+from ..core.exceptions import ProxyGatherException, ProxyParseException
 
 
 @dataclass

--- a/src/ballyregan/providers/geonode.py
+++ b/src/ballyregan/providers/geonode.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 from requests.exceptions import ConnectionError, JSONDecodeError
 
-from ballyregan import Proxy
-from ballyregan.providers import IProxyProvider
-from ballyregan.core.exceptions import ProxyGatherException
+from .. import Proxy
+from ..providers import IProxyProvider
+from ..core.exceptions import ProxyGatherException
 
 
 @dataclass

--- a/src/ballyregan/providers/interface.py
+++ b/src/ballyregan/providers/interface.py
@@ -6,8 +6,8 @@ from faker import Faker
 from requests import Session
 from loguru import logger
 
-from ballyregan import Proxy
-from ballyregan.core.exceptions import ProxyGatherException, ProxyParseException
+from .. import Proxy
+from ..core.exceptions import ProxyGatherException, ProxyParseException
 
 
 @dataclass

--- a/src/ballyregan/providers/proxy_list_download.py
+++ b/src/ballyregan/providers/proxy_list_download.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 
 from requests.exceptions import ConnectionError
 
-from ballyregan import Proxy
-from ballyregan.models import Protocols
-from ballyregan.providers import IProxyProvider
-from ballyregan.core.exceptions import ProxyGatherException, ProxyParseException
+from .. import Proxy
+from ..models import Protocols
+from ..providers import IProxyProvider
+from ..core.exceptions import ProxyGatherException, ProxyParseException
 
 
 @dataclass

--- a/src/ballyregan/providers/socks_proxy.py
+++ b/src/ballyregan/providers/socks_proxy.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from ballyregan import Proxy
-from ballyregan.providers import FreeProxyListProvider
-from ballyregan.core.exceptions import ProxyParseException
+from .. import Proxy
+from ..providers import FreeProxyListProvider
+from ..core.exceptions import ProxyParseException
 
 
 @dataclass

--- a/src/ballyregan/providers/ssl_proxies.py
+++ b/src/ballyregan/providers/ssl_proxies.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from ballyregan.providers import FreeProxyListProvider
+from ..providers import FreeProxyListProvider
 
 
 @dataclass

--- a/src/ballyregan/providers/us_proxy.py
+++ b/src/ballyregan/providers/us_proxy.py
@@ -1,4 +1,4 @@
-from ballyregan.providers.free_proxy_list import FreeProxyListProvider
+from ..providers.free_proxy_list import FreeProxyListProvider
 
 
 from dataclasses import dataclass

--- a/src/ballyregan/validator.py
+++ b/src/ballyregan/validator.py
@@ -12,9 +12,9 @@ from loguru import logger
 import urllib3
 from urllib3.connectionpool import InsecureRequestWarning
 
-from ballyregan import Proxy
-from ballyregan.models import Protocols
-from ballyregan.core.utils import get_event_loop
+from . import Proxy
+from .models import Protocols
+from .core.utils import get_event_loop
 
 
 @dataclass


### PR DESCRIPTION
Using python ping can require elevated permissions, even if ping does not. using requests solves that problem. also changing to makes it easier to test without installing using pip.